### PR TITLE
Don't mashify XML responses

### DIFF
--- a/lib/populi_api/connection.rb
+++ b/lib/populi_api/connection.rb
@@ -10,7 +10,6 @@ module PopuliAPI
 
     FARADAY_BUILDER_CONFIG = Proc.new do |builder|
       builder.request :url_encoded
-      builder.response :mashify  # Convert to Hashie::Mash
       builder.response :xml      # Parse XML
     end
 

--- a/lib/populi_api/connection.rb
+++ b/lib/populi_api/connection.rb
@@ -8,6 +8,12 @@ module PopuliAPI
   class Connection
     include Tasks
 
+    FARADAY_BUILDER_CONFIG = Proc.new do |builder|
+      builder.request :url_encoded
+      builder.response :mashify  # Convert to Hashie::Mash
+      builder.response :xml      # Parse XML
+    end
+
     attr_reader :config, :_connection
 
     def initialize(url: nil, access_key: nil, log_requests: false, inject_connection: nil)
@@ -48,9 +54,7 @@ module PopuliAPI
         url: config.url,
         headers: { "Authorization" => config.access_key }
       ) do |builder|
-        builder.request :url_encoded
-        builder.response :mashify  # Convert to Hashie::Mash
-        builder.response :xml      # Parse XML
+        FARADAY_BUILDER_CONFIG.call(builder)
 
         if config.log_requests
           builder.response :logger, nil, { bodies: false, log_level: :info }

--- a/lib/populi_api/version.rb
+++ b/lib/populi_api/version.rb
@@ -1,3 +1,3 @@
 module PopuliAPI
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -17,9 +17,8 @@ RSpec.describe PopuliAPI::Connection do
           ]
         end
       end
-      b.request :url_encoded
-      b.response :mashify
-      b.response :xml
+
+      PopuliAPI::Connection::FARADAY_BUILDER_CONFIG.call(b)
     end
   end
 

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -52,9 +52,10 @@ RSpec.describe PopuliAPI::Connection do
       subject.request(task: task, params: params)
     end
 
-    it "returns a parsed XML response as a Hashie::Mash structure" do
+    it "returns a parsed XML response as a Hash structure" do
       response = subject.request(task: task, params: params)
-      expect(response.body.response.result).to eq("SUCCESS")
+      expect(response.body.class).to eq(Hash)
+      expect(response.body["response"]["result"]).to eq("SUCCESS")
       stubs.verify_stubbed_calls
     end
   end
@@ -74,7 +75,7 @@ RSpec.describe PopuliAPI::Connection do
       result = subject.request_body(task: task, params: params)
 
       expect(result.keys).to contain_exactly("response")
-      expect(result.response.result).to eq("SUCCESS")
+      expect(result["response"]["result"]).to eq("SUCCESS")
     end
   end
 


### PR DESCRIPTION
Use regular XML parser for response data, i.e. Hashes with string keys.

- refactor(connection): Use proc to config Faraday
- feat(connection): Don't convert XML response to Hashie::Mash
- release: Version 0.2.0
