### PR TITLE
Add method getStudentEnrollment

### DIFF
--- a/lib/populi_api/tasks.rb
+++ b/lib/populi_api/tasks.rb
@@ -181,6 +181,7 @@ module PopuliAPI
     getStudentBalances
     getStudentDefaultTuitionSchedules
     getStudentDiscipline
+    getStudentEnrollment
     getStudentInfo
     getStudentMealPlan
     getStudentPrograms


### PR DESCRIPTION
New API method for Populi to get enrollment by student (person ID).

https://support.populiweb.com/hc/en-us/articles/223798747-API-Reference#getStudentEnrollment
